### PR TITLE
[HOTFIX] errorClear funckijai pievienots #msg lauciņš

### DIFF
--- a/register.php
+++ b/register.php
@@ -93,6 +93,7 @@ if(isset($_SESSION['user_id']))
             $('#password_msg').text('')
             $('#verify_password_msg').text('')
             $('#privacy_terms_msg').text('')
+            $('#msg').text('')
         }
 
         // Funkcija, kas parāda <message> vietā <type> (ErrorType)


### PR DESCRIPTION
 Pēc #15 pārbaudes ieraudzīju, ka atkārtotas reģistrācijas gadījumā vienā un tā pašā sesijā, `#msg` lauciņš netiek tīrīts.

Pievienoju to `errorClear` funkcijai.

**Labojums testēts un ieviests nekavējoties.**